### PR TITLE
Fix widgets (quite literally)

### DIFF
--- a/src/App/Main.fs
+++ b/src/App/Main.fs
@@ -433,6 +433,7 @@ let private fsharpEditorOptions (fontSize : float) (fontFamily : string) =
         o.minimap <- Some minimapOptions
         o.fontFamily <- Some fontFamily
         o.fontLigatures <- Some (fontFamily = "Fira Code")
+        o.fixedOverflowWidgets <- Some true
     )
 
 let private editorTabs (activeTab : CodeTab) dispatch =

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -203,7 +203,13 @@ html {
 
 .monaco-editor {
     .context-view {
+        z-index: 12000;
         position: fixed;
+    }
+    .monaco-editor-hover {
+        z-index: 12000;
+    }
+    .suggest-widget {
         z-index: 12000;
     }
 }


### PR DESCRIPTION
Setting `fixedOverflowWidgets` to `true` makes the widgets `position` be set to `fixed` instead of `absolute`, _fixing_ the problem.