### PR TITLE
Gist-based share link

### DIFF
--- a/src/App/Loader.fs
+++ b/src/App/Loader.fs
@@ -34,7 +34,7 @@ let urlUpdate (result: Option<Router.Page>) model =
             let (mainModel, mainCmd) = Main.init()
             Running mainModel, Cmd.map MainMsg mainCmd
 
-        | Running model -> Running model, Cmd.none
+        | Running model -> Running model, Cmd.ofMsg (MainMsg Main.UrlHashChange)
 
         | InvalidPlatform -> InvalidPlatform, Cmd.none
 
@@ -46,8 +46,11 @@ let urlUpdate (result: Option<Router.Page>) model =
 
     | Some page ->
         match page with
-        | Router.Home ->
+        | Router.Home | Router.LoadGist None->
             model, cmd
+        | Router.LoadGist (Some gist) ->
+            model, Cmd.batch [ cmd
+                               Cmd.ofMsg (MainMsg (Main.LoadGist gist)) ]
         // If user ask for reset, send a Reset message
         | Router.Reset ->
             model, Cmd.batch [ cmd

--- a/src/App/Router.fs
+++ b/src/App/Router.fs
@@ -10,18 +10,22 @@ let inline (</>) a b = a + "/" + string b
 type Page =
     | Reset
     | Home
+    | LoadGist of string option
 
 let private toHash page =
     let segmentsPart =
         match page with
         | Reset -> "reset"
-        | Home -> ""
+        | LoadGist (Some gist) -> "?gist="+gist
+        | Home | LoadGist None -> ""
+
 
     "#" + segmentsPart
 
 let pageParser: Parser<Page->Page,Page> =
     oneOf [
         map Reset (s "reset")
+        map LoadGist (top <?> stringParam "gist")
         map Home top ]
 
 let href route =

--- a/src/App/Sidebar.fs
+++ b/src/App/Sidebar.fs
@@ -23,6 +23,7 @@ type ExternalMsg =
     | NoOp
     | Reset
     | Share
+    | ShareToGist
 
 let init () =
     let samplesModel, samplesCmd = Widgets.Samples.init ()
@@ -61,6 +62,8 @@ let update msg model =
             | Widgets.General.NoOp -> NoOp
             | Widgets.General.Reset -> Reset
             | Widgets.General.ExternalMessage.Share -> Share
+            | Widgets.General.ExternalMessage.ShareToGist -> ShareToGist
+
 
         { model with General = generalModel }, Cmd.none, externalMsg
 
@@ -162,7 +165,7 @@ let private expandButton dispatch =
 
 let view (model: Model) (actionAreaExpanded, actionAreaCollapsed) dispatch =
     let widgets =
-        [ "General", Fa.I.Th, Widgets.General.view model.General (GeneralMsg >> dispatch), None
+        [ "General", Fa.I.Th, Widgets.General.view model.Options.GistToken model.General (GeneralMsg >> dispatch), None
           "Samples", Fa.I.Book, Widgets.Samples.view model.Samples (SamplesMsg >> dispatch), Some "500px"
           "Options", Fa.I.Cog, Widgets.Options.view model.Options (OptionsMsg >> dispatch), None
           "Statistics", Fa.I.ClockO, Widgets.Stats.view model.Statistics, None

--- a/src/App/Widgets/General.fs
+++ b/src/App/Widgets/General.fs
@@ -17,11 +17,13 @@ type Msg =
     | ConfirmReset
     | CancelReset
     | Share
+    | ShareToGist
 
 type ExternalMessage =
     | NoOp
     | Reset
     | Share
+    | ShareToGist
 
 let init () =
     { ResetState = Default }
@@ -40,12 +42,15 @@ let update msg model =
     | Msg.Share ->
         model, ExternalMessage.Share
 
-let view (model: Model) dispatch =
+    | Msg.ShareToGist ->
+        model, ExternalMessage.ShareToGist
+
+let view gistToken (model: Model) dispatch =
     let content =
         match model.ResetState with
         | Default ->
             div [ ]
-                [ Field.div [ Field.HasAddons ]
+                [ yield Field.div [ Field.HasAddons ]
                     [ Control.div [ ]
                         [ Button.button [ Button.OnClick (fun _ -> dispatch AskReset) ]
                             [ Icon.faIcon [ ]
@@ -56,7 +61,7 @@ let view (model: Model) dispatch =
                                           Button.IsFullWidth ]
                             [ Text.span [ ]
                                 [ str "Click here to reset" ] ] ] ]
-                  Field.div [ Field.HasAddons ]
+                  yield Field.div [ Field.HasAddons ]
                     [ Control.div [ ]
                         [ Button.button [ Button.OnClick (fun _ -> dispatch Msg.Share) ]
                             [ Icon.faIcon [ ]
@@ -66,7 +71,21 @@ let view (model: Model) dispatch =
                                           Button.IsText
                                           Button.IsFullWidth ]
                             [ Text.span [ ]
-                                [ str "Share" ] ] ] ] ]
+                                [ str "Share" ] ] ] ]
+                  match gistToken with
+                  | Some _ ->
+                    yield Field.div [ Field.HasAddons ]
+                        [ Control.div [ ]
+                            [ Button.button [ Button.OnClick (fun _ -> dispatch Msg.ShareToGist) ]
+                                [ Icon.faIcon [ ]
+                                    [ Fa.icon Fa.I.Github ] ] ]
+                          Control.div [ Control.IsExpanded ]
+                            [ Button.button [ Button.OnClick (fun _ -> dispatch Msg.ShareToGist)
+                                              Button.IsText
+                                              Button.IsFullWidth ]
+                                [ Text.span [ ]
+                                    [ str "Share to Gist" ] ] ] ]
+                  | None -> () ]
         | Confirm ->
             Field.div [ ]
                 [ Help.help [ Help.Color IsWarning ]


### PR DESCRIPTION
With this we can get a shareable link that is friendly in comparison with what we have now. Needs a github token with the gist scope, but it has a link that sends the user to the right place to get one.

May conflict with #48.