### PR TITLE
raw-loader/sharpziplib

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,3 +1,7 @@
+// fixup bad codepage for SharpZipLib
+#r @"packages\build\FAKE\tools\ICSharpCode.SharpZipLib.dll"
+do ICSharpCode.SharpZipLib.Zip.ZipConstants.DefaultCodePage <- 437
+
 open System
 open System.IO
 open System.Text.RegularExpressions

--- a/src/App/js/util.js
+++ b/src/App/js/util.js
@@ -27,6 +27,15 @@ function parseQuery() {
     }, {});
 }
 
+// see: https://github.com/webpack-contrib/raw-loader/issues/72
+function getString(a) {
+  if ("default" in a) {
+    return a.default;
+  } else {
+    return a;
+  }
+}
+
 export function updateQuery(code, html, css) {
     var object =
         { code : lzString.compressToEncodedURIComponent(code),
@@ -42,11 +51,11 @@ export function updateQuery(code, html, css) {
 export function loadState(key) {
     return Object.assign({
         // @ts-ignore
-        code: require("!raw-loader!./../../../public/samples/elmish/simple_input.fs"),
+        code: getString(require("!raw-loader!./../../../public/samples/elmish/simple_input.fs")),
         // @ts-ignore
-        html: require("!raw-loader!./../../../public/samples/elmish/simple_input.html"),
+        html: getString(require("!raw-loader!./../../../public/samples/elmish/simple_input.html")),
         // @ts-ignore
-        css: require("!raw-loader!./../../../public/samples/elmish/simple_input.css")
+        css: getString(require("!raw-loader!./../../../public/samples/elmish/simple_input.css"))
       },
       JSON.parse(window.localStorage.getItem(key)) || {},
       parseQuery()


### PR DESCRIPTION
Hi, since the raw-loader sometimes (couldn't figure out why or when) returns a `Module` with the code being in `.default` i added a function extracting the real code if it happened.
This seems to be a known issue: https://github.com/webpack-contrib/raw-loader/issues/72

I also worked around a nasty bug caused by some locale settings in SharpZipLib. see: https://stackoverflow.com/questions/46950386/sharpziplib-1-is-not-a-supported-code-page

