### PR TITLE
Fix Gitpod Build Issues

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -38,7 +38,7 @@ let METADATA_LIB, STANDALONE_DIST, STANDALONE_SRC =
     | Some _ ->
         printfn "Using local packages..."
         "../Fable/src/fable-metadata/lib", "../Fable/src/fable-standalone/dist", "../Fable/src/fable-standalone/src"
-    | None -> "node_modules/fable-metadata/lib", "node_modules/fable-standalone/dist", "node_modules/fable-standalone/dist"
+    | None -> "node_modules/fable-metadata/lib", "node_modules/fable-standalone/dist", "node_modules/fable-standalone/src"
 
 module Util =
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4269,9 +4269,9 @@
       "integrity": "sha512-lCXoctKzvHnkKJAO/TKPV20IRJ4OHM/Zn0ADucA0yMJdK1BVILmslhUTgCp3LIRLXk1S1UQ3Pmmo6ZsFznFYRw=="
     },
     "fable-standalone": {
-      "version": "3.0.0-nagareyama-rc-008",
-      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-3.0.0-nagareyama-rc-008.tgz",
-      "integrity": "sha512-rTW5YNEdKaR1Z2q61upJfu47mIIqkPi9mRiBRSh6VLSQjwHGe32wM58B3f8PmpBnl6MA6k/kIUMtgZmJcHlBOg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-3.0.0.tgz",
+      "integrity": "sha512-lstvLjO/bjT6GJrjYC7smAxys1gPJST3KOi/0qz0Pb4z/cEh0mo3R/tGAZQTKrzKcyxL4fRE+r0bHdjY1MHCBA=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^3.6.0",
     "fable-metadata": "^2.0.0",
-    "fable-standalone": "^3.0.0-nagareyama-rc-008",
+    "fable-standalone": "3.0.0",
     "file-loader": "^6.0.0",
     "gh-pages": "^3.1.0",
     "html-webpack-plugin": "^4.3.0",

--- a/src/App/Prelude.fs
+++ b/src/App/Prelude.fs
@@ -29,7 +29,7 @@ module Literals =
           "Browser.Event"
           "Browser.WebStorage"
           "Browser.Dom"
-          "Browser.WebGL"
+        //   "Browser.WebGL"
         //   "Fable.Repl.Lib"
         |]
 


### PR DESCRIPTION
Building the Repl on Gitpod seems broken. I think the local packages are ahead of what is available on npm?  
Also there was a bug resolving fable-standalone src node module. 

This gets the Repl running, but breaks samples relying on the WebGL metadata. Loving Fable 😄 



