### PR TITLE
Update inaccurate comment about Java in the tour

### DIFF
--- a/src/App/public/samples/tour/classes.fs
+++ b/src/App/public/samples/tour/classes.fs
@@ -83,7 +83,7 @@ type ReadFile(path: string) =
 
 
 /// This is an object that implements IDisposable via an Object Expression
-/// Unlike other languages such as C# or Java, a new type definition is not needed
+/// Unlike other languages such as C#, a new type definition is not needed
 /// to implement an interface.
 let interfaceImplementation =
     { new System.IDisposable with


### PR DESCRIPTION
Java has a feature called _anonymous classes_ that works practically the same as object expressions in F#, and that's a pretty old feature, introduced even before Java 8 I think. Check some examples [here](https://docs.oracle.com/javase/tutorial/java/javaOO/anonymousclasses.html).

Before Java 8, that feature was widely used to get something like lambda expressions, but with a tiny bit less terse syntax, like this:
```java
interface MyFunctionLike {
  int run();
}

MyFunctionLike aBitLikeLambda = new MyFunctionLike {
  @Override
  public int run() {
    return 2 + 2;
  }
};
```

The full analog in F# would be
```fsharp
type MyFunctionLike =
  abstract member run: unit -> int

let aBitLikeLambda =
  { interface MyFunctionLike with
    member _.run() = 2 + 2 }
```

So, the comment in question is inaccurate, and I suggest to avoid mentioning Java there.